### PR TITLE
Enable deploying to multiple environments and cleanup old passcode fu…

### DIFF
--- a/src/commands/rtc/apps/video/delete.js
+++ b/src/commands/rtc/apps/video/delete.js
@@ -8,7 +8,7 @@ class DeleteCommand extends TwilioClientCommand {
 
     if (appInfo) {
       await this.twilioClient.serverless.services(appInfo.sid).remove();
-      console.log(`Removed app with Passcode: ${appInfo.passcode}`);
+      console.log(`Removed app with URL: ${appInfo.url}`);
     } else {
       console.log('There is no app to delete');
     }
@@ -21,7 +21,7 @@ DeleteCommand.description = 'Delete a Programmable Video app';
 
 DeleteCommand.examples = [
   `$ twilio rtc:apps:video:delete
-Removed app with Passcode: 1111111111`,
+Removed app with URL: https://video-app-4023-dev.twil.io`,
 ];
 
 module.exports = DeleteCommand;

--- a/src/commands/rtc/apps/video/deploy.js
+++ b/src/commands/rtc/apps/video/deploy.js
@@ -42,13 +42,19 @@ DeployCommand.flags = Object.assign(
       default: false,
       description: 'Override an existing App deployment',
     }),
+    environment: flags.enum({
+      options: ['dev', 'prod'],
+      description: 'The environment to deploy the function and assets: dev, prod.',
+      required: false,
+      default: 'dev',
+    }),
   },
   TwilioClientCommand.flags
 );
 
 DeployCommand.usage = 'rtc:apps:video:deploy --authentication <auth>';
 
-DeployCommand.description = `Deploy a Programmable Video app 
+DeployCommand.description = `Deploy a Programmable Video app
 
 This command publishes two components as a Twilio Function: an application token
 server and an optional React application.
@@ -70,6 +76,13 @@ $ twilio rtc:apps:video:deploy --authentication passcode
 deploying app... done
 Passcode: 1111111111`,
   `
+# Deploy an application token server to production environment
+# There are two environments: "dev" and "prod". "dev" is default.
+# This is an optional flag. Defualts to "dev", development environment
+$ twilio rtc:apps:video:deploy --authentication passcode --environment prod
+deploying app... done
+Passcode: 1111111111`,
+  `
 # Deploy an application token server with the React app
 $ twilio rtc:apps:video:deploy --authentication passcode --app-directory /path/to/app
 deploying app... done
@@ -79,7 +92,7 @@ Passcode: 1111111111`,
 # Override an existing app with a fresh deployment
 # Please note that this will remove a previously deployed web application if no
 # app directory is provided
-$ twilio rtc:apps:video:deploy --authentication passcode --override 
+$ twilio rtc:apps:video:deploy --authentication passcode --override
 Removed app with Passcode: 1111111111
 deploying app... done
 Passcode: 2222222222

--- a/src/commands/rtc/apps/video/deploy.js
+++ b/src/commands/rtc/apps/video/deploy.js
@@ -78,7 +78,7 @@ Passcode: 1111111111`,
   `
 # Deploy an application token server to production environment
 # There are two environments: "dev" and "prod". "dev" is default.
-# This is an optional flag. Defualts to "dev", development environment
+# This is an optional flag. Defaults to "dev", development environment
 $ twilio rtc:apps:video:deploy --authentication passcode --environment prod
 deploying app... done
 Passcode: 1111111111`,

--- a/src/commands/rtc/apps/video/deploy.js
+++ b/src/commands/rtc/apps/video/deploy.js
@@ -19,11 +19,11 @@ class DeployCommand extends TwilioClientCommand {
 
     if (this.appInfo && !this.flags.override) {
       console.log('A Video app is already deployed. Use the --override flag to override the existing deployment.');
-      await displayAppInfo.call(this);
+      await displayAppInfo.call(this, this.flags['environment']);
       return;
     }
     await deploy.call(this);
-    await displayAppInfo.call(this);
+    await displayAppInfo.call(this, this.flags['environment']);
   }
 }
 DeployCommand.flags = Object.assign(

--- a/src/commands/rtc/apps/video/view.js
+++ b/src/commands/rtc/apps/video/view.js
@@ -14,8 +14,8 @@ ViewCommand.description = 'View a Programmable Video app';
 
 ViewCommand.examples = [
   `$ twilio rtc:apps:video:view
-Web App URL: https://video-app-1111-dev.twil.io?passcode=1111111111
-Passcode: 1111111111`,
+Web App URL: https://video-app-1111-dev.twil.io
+`,
 ];
 
 module.exports = ViewCommand;

--- a/src/commands/rtc/apps/video/view.js
+++ b/src/commands/rtc/apps/video/view.js
@@ -4,7 +4,7 @@ const { TwilioClientCommand } = require('@twilio/cli-core').baseCommands;
 class ViewCommand extends TwilioClientCommand {
   async run() {
     await super.run();
-    await displayAppInfo.call(this);
+    await displayAppInfo.call(this, this.flags['environment']);
   }
 }
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,2 +1,2 @@
-module.exports.APP_NAME = 'video-app';
+module.exports.APP_NAME = 'with-app';
 module.exports.EXPIRY_PERIOD = 1000 * 60 * 60 * 24 * 7; // One week

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -95,8 +95,6 @@ async function displayAppInfo(env) {
     console.log(`Web App URL: ${appInfo.url}`);
   }
   console.log(`App SID: ${appInfo.sid}`);
-  // console.log(`Passcode: ${appInfo.passcode}`);
-  // console.log(`Expires: ${appInfo.expiry}`);
 }
 
 async function deploy() {
@@ -118,8 +116,6 @@ async function deploy() {
     env: {
       TWILIO_API_KEY_SID: this.twilioClient.username,
       TWILIO_API_KEY_SECRET: this.twilioClient.password,
-      // API_PASSCODE: pin,
-      // API_PASSCODE_EXPIRY: expiryTime,
     },
     pkgJson: {},
     functionsEnv: environment,

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -77,19 +77,20 @@ async function getAppInfo() {
 
   const assets = await appInstance.assets.list();
 
-  const passcodeVar = variables.find(v => v.key === 'API_PASSCODE');
-  const expiryVar = variables.find(v => v.key === 'API_PASSCODE_EXPIRY');
+  // const passcodeVar = variables.find(v => v.key === 'API_PASSCODE');
+  // const expiryVar = variables.find(v => v.key === 'API_PASSCODE_EXPIRY');
 
-  const passcode = passcodeVar ? passcodeVar.value : '';
-  const expiry = expiryVar ? expiryVar.value : '';
+  // const passcode = passcodeVar ? passcodeVar.value : '';
+  // const expiry = expiryVar ? expiryVar.value : '';
 
-  const fullPasscode = getPasscode(environment.domainName, passcode);
+  // const fullPasscode = getPasscode(environment.domainName, passcode);
 
   return {
-    url: `https://${environment.domainName}?passcode=${fullPasscode}`,
-    expiry: moment(Number(expiry)).toString(),
+    url: `https://${environment.domainName}`,
+    // url: `https://${environment.domainName}?passcode=${fullPasscode}`,
+    // expiry: moment(Number(expiry)).toString(),
     sid: app.sid,
-    passcode: fullPasscode,
+    // passcode: fullPasscode,
     hasAssets: Boolean(assets.length),
   };
 }
@@ -105,20 +106,21 @@ async function displayAppInfo() {
   if (appInfo.hasAssets) {
     console.log(`Web App URL: ${appInfo.url}`);
   }
-  console.log(`Passcode: ${appInfo.passcode}`);
-  console.log(`Expires: ${appInfo.expiry}`);
+  // console.log(`Passcode: ${appInfo.passcode}`);
+  // console.log(`Expires: ${appInfo.expiry}`);
 }
 
 async function deploy() {
   const assets = this.flags['app-directory'] ? await getAssets(this.flags['app-directory']) : [];
+  const environment = this.flags['environment'];
 
   const serverlessClient = new TwilioServerlessApiClient({
     accountSid: this.twilioClient.username,
     authToken: this.twilioClient.password,
   });
 
-  const pin = getPin();
-  const expiryTime = Date.now() + EXPIRY_PERIOD;
+  // const pin = getPin();
+  // const expiryTime = Date.now() + EXPIRY_PERIOD;
 
   const fn = fs.readFileSync(path.join(__dirname, './video-token-server.js'));
 
@@ -128,11 +130,11 @@ async function deploy() {
     env: {
       TWILIO_API_KEY_SID: this.twilioClient.username,
       TWILIO_API_KEY_SECRET: this.twilioClient.password,
-      API_PASSCODE: pin,
-      API_PASSCODE_EXPIRY: expiryTime,
+      // API_PASSCODE: pin,
+      // API_PASSCODE_EXPIRY: expiryTime,
     },
     pkgJson: {},
-    functionsEnv: 'dev',
+    functionsEnv: environment,
     functions: [
       {
         name: 'token',

--- a/test/helpers/helpers.test.js
+++ b/test/helpers/helpers.test.js
@@ -54,7 +54,7 @@ function getMockTwilioInstance(options) {
     },
   }));
   mockAppInstance.environments.list = () =>
-    Promise.resolve([{ sid: 'env', domainName: `${APP_NAME}-5678-dev.twil.io` }]);
+    Promise.resolve([{ sid: 'env', domainSuffix: 'dev', domainName: `${APP_NAME}-5678-dev.twil.io` }]);
   mockTwilioClient.serverless.services = jest.fn(() => Promise.resolve(mockAppInstance));
   mockTwilioClient.serverless.services.list = () =>
     Promise.resolve([
@@ -170,11 +170,9 @@ describe('the getAppInfo function', () => {
       twilioClient: getMockTwilioInstance({ exists: true }),
     });
     expect(result).toEqual({
-      expiry: 'Wed May 20 2020 18:40:00 GMT+0000',
       hasAssets: false,
-      passcode: '1234565678',
       sid: 'appSid',
-      url: 'https://video-app-5678-dev.twil.io?passcode=1234565678',
+      url: 'https://with-app-5678-dev.twil.io',
     });
   });
 
@@ -183,11 +181,9 @@ describe('the getAppInfo function', () => {
       twilioClient: getMockTwilioInstance({ exists: true, hasAssets: true }),
     });
     expect(result).toEqual({
-      expiry: 'Wed May 20 2020 18:40:00 GMT+0000',
       hasAssets: true,
-      passcode: '1234565678',
       sid: 'appSid',
-      url: 'https://video-app-5678-dev.twil.io?passcode=1234565678',
+      url: 'https://with-app-5678-dev.twil.io',
     });
   });
 
@@ -208,8 +204,7 @@ describe('the displayAppInfo function', () => {
       twilioClient: getMockTwilioInstance({ exists: true }),
     });
     expect(stdout.output).toMatchInlineSnapshot(`
-      "Passcode: 1234565678
-      Expires: Wed May 20 2020 18:40:00 GMT+0000
+      "App SID: appSid
       "
     `);
   });
@@ -219,9 +214,8 @@ describe('the displayAppInfo function', () => {
       twilioClient: getMockTwilioInstance({ exists: true, hasAssets: true }),
     });
     expect(stdout.output).toMatchInlineSnapshot(`
-      "Web App URL: https://video-app-5678-dev.twil.io?passcode=1234565678
-      Passcode: 1234565678
-      Expires: Wed May 20 2020 18:40:00 GMT+0000
+      "Web App URL: https://with-app-5678-dev.twil.io
+      App SID: appSid
       "
     `);
   });


### PR DESCRIPTION
This work adds an extra parameter to our deployment script to specify an --environment parameter that can be either "dev" or "prod".

I also cleaned up some of the old Twilio application passcode functionality so that folks wouldn't be confused going forward.

There will be a complimentary pull request on the With repo to utilize this functionality.